### PR TITLE
fix(asHtmlStyleString): call the preset function

### DIFF
--- a/src/flex-jss.js
+++ b/src/flex-jss.js
@@ -129,7 +129,7 @@ export const css = {
  * @returns {string}
  */
 export const asHtmlStyleString = () => {
-  const jss = new Jss(preset)
+  const jss = new Jss(preset())
   const options = {named: false}
   return jss.createStyleSheet(prefixCSS('.flb', css), options).toString()
 }


### PR DESCRIPTION
css styles were being generated incorrectly because the preset was not used properly